### PR TITLE
adjusted the lesson start buttons

### DIFF
--- a/packages/daheim-app-ui/src/components/InvitedToLesson.js
+++ b/packages/daheim-app-ui/src/components/InvitedToLesson.js
@@ -64,9 +64,10 @@ class InvitedToLessonDialog extends Component {
       <FlatButton
         key='start'
         className='start'
-        label='Gespräch starten'
+        label={'LOS GEHT\'S'}
         primary
         onTouchTap={this.handleAccept}
+        style={{color: 'white', backgroundColor: '#E61C78', fontWeight: 'bold'}}
       />
     ]
 
@@ -76,7 +77,7 @@ class InvitedToLessonDialog extends Component {
           {actions}
         </div>
         <h2>Neues Gespräch</h2>
-        <ProfilePage params={{userId: this.props.lesson.teacherId}} reviewEditable={false} onReportUser={this.handleReportUser} />
+        <ProfilePage params={{userId: this.props.lesson.teacherId}} reviewEditable={false} />
       </Modal>
     )
   }

--- a/packages/daheim-app-ui/src/components/StartLesson.js
+++ b/packages/daheim-app-ui/src/components/StartLesson.js
@@ -99,10 +99,11 @@ class StartLesson extends Component {
       <FlatButton
         key='start'
         className='start'
-        label='Gespräch starten'
+        label={'los geht\'s'}
         primary
         disabled={!!(startLessonPromise || lessonId)}
         onTouchTap={this.handleStartLesson}
+        style={{color: 'white', backgroundColor: '#E61C78', fontWeight: 'bold'}}
       />
     ]
 

--- a/packages/daheim-app-ui/src/components/profile/PublicProfilePage.js
+++ b/packages/daheim-app-ui/src/components/profile/PublicProfilePage.js
@@ -71,6 +71,8 @@ class ProfilePage extends Component {
   }
 
   render () {
+    console.log(this.props)
+
     const {user, userMeta, me, reviewEditable} = this.props
 
     const userNotFound = userMeta && userMeta.error && userMeta.error.code === 'user_not_found'
@@ -107,7 +109,7 @@ class ProfilePage extends Component {
             <div style={{fontSize: 30, fontWeight: 600, fontFamily: 'Lato, sans-serif', lineHeight: '150%'}}>
               <span style={{marginRight: 10}}>{name} </span>
               {me ? <Link to='/profile' className={css.editButton}><FormattedMessage id='profile.edit' /></Link> : null}
-              {!me ? <a onClick={this.handleReport} href='#' className={css.editButton}><FormattedMessage id='profile.reportUser' /></a> : null}
+              {!me && this.props.onReportUser ? <a onClick={this.handleReport} href='#' className={css.editButton}><FormattedMessage id='profile.reportUser' /></a> : null}
             </div>
             <div style={{fontSize: 14, fontFamily: 'Lato, sans-serif', lineHeight: '150%'}}>{this.roleToTitle(role)}</div>
           </div>


### PR DESCRIPTION
Hi, Sarah told me that a lot of users are confused about the "mitbewohner melden" button and clicked it often instead of starting a new lesson. So I disabled it the lesson start panel and made the start button more prominent. 
I hope this will help the people to find the right way to their students.
You can still report users after talking to them.