### PR TITLE
Update ReadyPage.js

### DIFF
--- a/packages/daheim-app-ui/src/containers/ReadyPage.js
+++ b/packages/daheim-app-ui/src/containers/ReadyPage.js
@@ -55,8 +55,9 @@ class ReadyOrNotYetOpen extends Component {
   }
 
   render () {
-    if (this.props.accepted) return <ReadyPage />
-    return <NotYetOpenPage />
+    // if (this.props.accepted) return <ReadyPage />
+    // return <NotYetOpenPage />
+    return <ReadyPage />
   }
 }
 


### PR DESCRIPTION
Quick fix to disable the bob the baumeister Sarah asked me to clear out. would be better to completely delete the ReadyOrNotYetOpen class. I'm not sure if this is needed later on.